### PR TITLE
Render eyes with egui primitives

### DIFF
--- a/pupper-rs/src/main.rs
+++ b/pupper-rs/src/main.rs
@@ -1,43 +1,102 @@
 use eframe::{App, egui};
-use egui_extras::image::load_image_bytes;
-use std::path::PathBuf;
+use egui::{Color32, Pos2, Shape, Stroke, Vec2};
 
-struct ImageApp {
-    // texture: egui::TextureHandle,
-    // size: egui::Vec2,
-}
+struct ImageApp;
 
 impl ImageApp {
-    fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        egui_extras::install_image_loaders(&cc.egui_ctx);
-        // let image_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        //     .join("..")
-        //     .join("infra")
-        //     .join("pupper_image_builder")
-        //     .join("resources")
-        //     .join("blue_eyes.jpg");
-        // let bytes = std::fs::read(image_path).expect("failed to read blue_eyes.jpg");
-        // let image = load_image_bytes(&bytes).expect("invalid image data");
-        // let size = egui::Vec2::new(image.width() as f32, image.height() as f32);
-        // let texture = cc
-        //     .egui_ctx
-        //     .load_texture("blue_eyes", image, egui::TextureOptions::default());
-        // Self { texture, size }
-        Self {}
+    fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+        Self
     }
+}
+
+fn quadratic_bezier_points(start: Pos2, ctrl: Pos2, end: Pos2, steps: usize) -> Vec<Pos2> {
+    (0..=steps)
+        .map(|i| {
+            let t = i as f32 / steps as f32;
+            let u = 1.0 - t;
+            Pos2 {
+                x: u * u * start.x + 2.0 * u * t * ctrl.x + t * t * end.x,
+                y: u * u * start.y + 2.0 * u * t * ctrl.y + t * t * end.y,
+            }
+        })
+        .collect()
+}
+
+fn draw_eye(painter: &egui::Painter, center: Pos2) {
+    let iris_outer = Color32::from_rgb(0x08, 0x12, 0x20);
+    let iris_mid = Color32::from_rgb(0x0b, 0x17, 0x27);
+    let iris_inner = Color32::from_rgb(0x00, 0x84, 0xff);
+    let iris_ring = Color32::from_rgba_unmultiplied(0x00, 0xa6, 0xff, 180);
+
+    painter.add(Shape::circle_filled(center, 126.0, iris_outer));
+    painter.add(Shape::circle_filled(center, 88.0, iris_mid));
+    painter.add(Shape::circle_filled(center, 40.0, iris_inner));
+    painter.add(Shape::circle_stroke(
+        center,
+        126.0,
+        Stroke::new(6.0, iris_ring),
+    ));
+
+    painter.add(Shape::circle_filled(center, 96.0, Color32::BLACK));
+
+    let iris_blue = Color32::from_rgb(0x00, 0xa6, 0xff);
+    let arc_start = center + Vec2::new(-62.0, 38.0);
+    let arc_ctrl = center + Vec2::new(0.0, -36.0);
+    let arc_end = center + Vec2::new(58.0, 38.0);
+    let arc_points = quadratic_bezier_points(arc_start, arc_ctrl, arc_end, 20);
+    painter.add(Shape::line(arc_points, Stroke::new(17.0, iris_blue)));
+    painter.add(Shape::circle_filled(
+        center + Vec2::new(70.0, 42.0),
+        8.0,
+        iris_blue,
+    ));
+
+    painter.add(Shape::circle_filled(
+        center + Vec2::new(-29.0, -51.0),
+        31.0,
+        Color32::from_rgba_unmultiplied(255, 255, 255, (0.96 * 255.0) as u8),
+    ));
+    painter.add(Shape::circle_filled(
+        center + Vec2::new(18.0, -17.0),
+        14.0,
+        Color32::from_rgba_unmultiplied(255, 255, 255, (0.90 * 255.0) as u8),
+    ));
+
+    let brow_start = center + Vec2::new(-84.0, -180.0);
+    let brow_ctrl = center + Vec2::new(0.0, -204.0);
+    let brow_end = center + Vec2::new(84.0, -180.0);
+    let brow_points = quadratic_bezier_points(brow_start, brow_ctrl, brow_end, 20);
+    let brow_color = Color32::from_rgba_unmultiplied(0xb9, 0xb9, 0xb9, (0.8 * 255.0) as u8);
+    painter.add(Shape::line(brow_points, Stroke::new(10.0, brow_color)));
 }
 
 impl App for ImageApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.image(egui::include_image!("blue_eyes.png"));
+            let (rect, _) = ui.allocate_exact_size(Vec2::new(900.0, 420.0), egui::Sense::hover());
+            let painter = ui.painter_at(rect);
+
+            let halo_color = Color32::from_rgba_unmultiplied(0x00, 0xb4, 0xff, 60);
+            painter.add(Shape::circle_filled(
+                Pos2::new(220.0, 210.0),
+                150.0,
+                halo_color,
+            ));
+            painter.add(Shape::circle_filled(
+                Pos2::new(680.0, 210.0),
+                150.0,
+                halo_color,
+            ));
+
+            draw_eye(&painter, Pos2::new(220.0, 210.0));
+            draw_eye(&painter, Pos2::new(680.0, 210.0));
         });
     }
 }
 
 fn main() -> eframe::Result<()> {
     let options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_inner_size([720.0, 720.0]),
+        viewport: egui::ViewportBuilder::default().with_inner_size([900.0, 420.0]),
         ..Default::default()
     };
     eframe::run_native(


### PR DESCRIPTION
## Summary
- draw halo and eye shapes using egui primitives instead of image
- approximate SVG gradients and highlights with custom painter code

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68b0a946989c832a8b8f11c3468bdc81