### PR TITLE
Add GitHub token support for image builder

### DIFF
--- a/infra/pupper_image_builder/make_pios_ai_image.sh
+++ b/infra/pupper_image_builder/make_pios_ai_image.sh
@@ -1,5 +1,21 @@
 #!/bin/bash -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+ENV_FILE="${SCRIPT_DIR}/.env.local"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+DOCKER_ENV_ARGS=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  DOCKER_ENV_ARGS+=(--env GITHUB_TOKEN)
+fi
+
 set -x
 
 #### Parse command line arguments
@@ -33,8 +49,8 @@ if [ "$INCLUDE_KEYS" = true ]; then
 fi
 
 docker pull mkaczanowski/packer-builder-arm:latest
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest init pios_ai_arm64.pkr.hcl
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build -only=$PACKER_ONLY pios_ai_arm64.pkr.hcl
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build "${DOCKER_ENV_ARGS[@]}" mkaczanowski/packer-builder-arm:latest init pios_ai_arm64.pkr.hcl
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build "${DOCKER_ENV_ARGS[@]}" mkaczanowski/packer-builder-arm:latest build -only=$PACKER_ONLY pios_ai_arm64.pkr.hcl
 
 # If including keys, rename the resulting image with _WITH_SECRETS suffix
 if [ "$INCLUDE_KEYS" = true ] && [ -f "pupOS_pios_ai.img" ]; then

--- a/infra/pupper_image_builder/make_pios_base_image.sh
+++ b/infra/pupper_image_builder/make_pios_base_image.sh
@@ -1,7 +1,23 @@
 #!/bin/bash -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+ENV_FILE="${SCRIPT_DIR}/.env.local"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+DOCKER_ENV_ARGS=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  DOCKER_ENV_ARGS+=(--env GITHUB_TOKEN)
+fi
+
 set -x
 
 docker pull mkaczanowski/packer-builder-arm:latest
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest init pios_base_arm64.pkr.hcl
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build pios_base_arm64.pkr.hcl
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build "${DOCKER_ENV_ARGS[@]}" mkaczanowski/packer-builder-arm:latest init pios_base_arm64.pkr.hcl
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build "${DOCKER_ENV_ARGS[@]}" mkaczanowski/packer-builder-arm:latest build pios_base_arm64.pkr.hcl

--- a/infra/pupper_image_builder/make_pios_full_image.sh
+++ b/infra/pupper_image_builder/make_pios_full_image.sh
@@ -1,5 +1,21 @@
 #!/bin/bash -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+ENV_FILE="${SCRIPT_DIR}/.env.local"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+DOCKER_ENV_ARGS=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  DOCKER_ENV_ARGS+=(--env GITHUB_TOKEN)
+fi
+
 set -x
 
 # Check if the image exists
@@ -11,5 +27,5 @@ else
 fi
 
 docker pull mkaczanowski/packer-builder-arm:latest
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest init pios_full_arm64.pkr.hcl
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build pios_full_arm64.pkr.hcl
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build "${DOCKER_ENV_ARGS[@]}" mkaczanowski/packer-builder-arm:latest init pios_full_arm64.pkr.hcl
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build "${DOCKER_ENV_ARGS[@]}" mkaczanowski/packer-builder-arm:latest build pios_full_arm64.pkr.hcl

--- a/infra/pupper_image_builder/make_server_image.sh
+++ b/infra/pupper_image_builder/make_server_image.sh
@@ -1,7 +1,23 @@
 #!/bin/bash -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+ENV_FILE="${SCRIPT_DIR}/.env.local"
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+DOCKER_ENV_ARGS=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  DOCKER_ENV_ARGS+=(--env GITHUB_TOKEN)
+fi
+
 set -x
 
 docker pull mkaczanowski/packer-builder-arm:latest
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest init ubuntu_server_24.04_arm64.pkr.hcl
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build ubuntu_server_24.04_arm64.pkr.hcl
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build "${DOCKER_ENV_ARGS[@]}" mkaczanowski/packer-builder-arm:latest init ubuntu_server_24.04_arm64.pkr.hcl
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build "${DOCKER_ENV_ARGS[@]}" mkaczanowski/packer-builder-arm:latest build ubuntu_server_24.04_arm64.pkr.hcl

--- a/infra/pupper_image_builder/pios_ai_arm64.pkr.hcl
+++ b/infra/pupper_image_builder/pios_ai_arm64.pkr.hcl
@@ -60,7 +60,8 @@ build {
 
   # Common provisioning script
   provisioner "shell" {
-    script = "provision_pios_ai.sh"
+    script           = "provision_pios_ai.sh"
+    environment_vars = ["GITHUB_TOKEN={{ env `GITHUB_TOKEN` }}"]
   }
 
   # Ensure destination directory exists (with-keys only)

--- a/infra/pupper_image_builder/pios_full_arm64.pkr.hcl
+++ b/infra/pupper_image_builder/pios_full_arm64.pkr.hcl
@@ -55,7 +55,8 @@ build {
   }
 
   provisioner "shell" {
-    script = "provision_pios_full.sh"
+    script            = "provision_pios_full.sh"
+    environment_vars  = ["GITHUB_TOKEN={{ env `GITHUB_TOKEN` }}"]
   }
 
   provisioner "file" {

--- a/infra/pupper_image_builder/provision_pios_ai.sh
+++ b/infra/pupper_image_builder/provision_pios_ai.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=setup_scripts/github_auth.sh
+source "${SCRIPT_DIR}/setup_scripts/github_auth.sh"
+trap cleanup_github_auth EXIT
+
 set -x
 
 # Function to retry a command
@@ -70,7 +75,9 @@ pip install pandas
 cd /home/$DEFAULT_USER/pupperv3-monorepo/
 chown -R $DEFAULT_USER:$DEFAULT_USER /home/$DEFAULT_USER/pupperv3-monorepo/
 git config --global --add safe.directory /home/$DEFAULT_USER/pupperv3-monorepo
+setup_github_auth
 git pull
+cleanup_github_auth
 
 ############################## Download turn detector model #############################################
 cd /home/$DEFAULT_USER/pupperv3-monorepo/ai/llm-ui/agent-starter-python/

--- a/infra/pupper_image_builder/provision_pios_full.sh
+++ b/infra/pupper_image_builder/provision_pios_full.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=setup_scripts/github_auth.sh
+source "${SCRIPT_DIR}/setup_scripts/github_auth.sh"
+trap cleanup_github_auth EXIT
+
 set -x
 
 # Function to retry a command
@@ -81,11 +86,13 @@ pip install "python-dotenv"
 # Prepare monorepo
 apt install git-lfs -y
 cd /home/$DEFAULT_USER
+setup_github_auth
 retry_command "git clone https://github.com/Nate711/pupperv3-monorepo.git --recurse-submodules"
 cd /home/$DEFAULT_USER/pupperv3-monorepo/
 chown -R pi:pi .
 git lfs install
 git lfs pull
+cleanup_github_auth
 
 ############################## Install ros2 deps from source ##################################
 

--- a/infra/pupper_image_builder/setup_scripts/github_auth.sh
+++ b/infra/pupper_image_builder/setup_scripts/github_auth.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Helper functions to configure git to use a GitHub token via GIT_ASKPASS
+# without persisting the token to disk.
+
+setup_github_auth() {
+    if [ -z "${GITHUB_TOKEN:-}" ]; then
+        return 0
+    fi
+
+    if [ -n "${_GIT_ASKPASS_SCRIPT:-}" ]; then
+        return 0
+    fi
+
+    _GIT_ASKPASS_SCRIPT="$(mktemp /tmp/git-askpass-XXXXXX)"
+
+    cat <<'SCRIPT' > "${_GIT_ASKPASS_SCRIPT}"
+#!/bin/sh
+case "$1" in
+    Username*)
+        echo "x-access-token"
+        ;;
+    Password*)
+        echo "${GITHUB_TOKEN:-}"
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+SCRIPT
+
+    chmod 700 "${_GIT_ASKPASS_SCRIPT}"
+
+    if [ -n "${GIT_ASKPASS:-}" ]; then
+        _GIT_PREV_GIT_ASKPASS="${GIT_ASKPASS}"
+    else
+        unset _GIT_PREV_GIT_ASKPASS
+    fi
+
+    if [ -n "${GIT_TERMINAL_PROMPT:-}" ]; then
+        _GIT_PREV_GIT_TERMINAL_PROMPT="${GIT_TERMINAL_PROMPT}"
+    else
+        unset _GIT_PREV_GIT_TERMINAL_PROMPT
+    fi
+
+    export GIT_ASKPASS="${_GIT_ASKPASS_SCRIPT}"
+    export GIT_TERMINAL_PROMPT=0
+    return 0
+}
+
+cleanup_github_auth() {
+    if [ -n "${_GIT_ASKPASS_SCRIPT:-}" ]; then
+        rm -f "${_GIT_ASKPASS_SCRIPT}"
+    fi
+
+    if [ -n "${_GIT_PREV_GIT_ASKPASS+x}" ]; then
+        if [ -n "${_GIT_PREV_GIT_ASKPASS:-}" ]; then
+            export GIT_ASKPASS="${_GIT_PREV_GIT_ASKPASS}"
+        else
+            unset GIT_ASKPASS
+        fi
+    else
+        unset GIT_ASKPASS
+    fi
+
+    if [ -n "${_GIT_PREV_GIT_TERMINAL_PROMPT+x}" ]; then
+        if [ -n "${_GIT_PREV_GIT_TERMINAL_PROMPT:-}" ]; then
+            export GIT_TERMINAL_PROMPT="${_GIT_PREV_GIT_TERMINAL_PROMPT}"
+        else
+            unset GIT_TERMINAL_PROMPT
+        fi
+    else
+        unset GIT_TERMINAL_PROMPT
+    fi
+
+    unset _GIT_ASKPASS_SCRIPT
+    unset _GIT_PREV_GIT_ASKPASS
+    unset _GIT_PREV_GIT_TERMINAL_PROMPT
+
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        unset GITHUB_TOKEN
+    fi
+
+    return 0
+}


### PR DESCRIPTION
## Summary
- load GITHUB_TOKEN from .env.local in the image build scripts and forward it to packer
- expose the token to packer provisioners and use a shared GIT_ASKPASS helper so git/LFS auth works without persisting credentials

## Testing
- bash -n infra/pupper_image_builder/make_pios_ai_image.sh
- bash -n infra/pupper_image_builder/make_pios_base_image.sh
- bash -n infra/pupper_image_builder/make_pios_full_image.sh
- bash -n infra/pupper_image_builder/make_server_image.sh
- bash -n infra/pupper_image_builder/provision_pios_ai.sh
- bash -n infra/pupper_image_builder/provision_pios_full.sh
- bash -n infra/pupper_image_builder/setup_scripts/github_auth.sh

------
https://chatgpt.com/codex/tasks/task_e_68c908c937f8832a8bbca679aa4c8f29